### PR TITLE
Fixed searching of a prefix of a key in object

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -325,7 +325,9 @@ namespace sajson {
             const object_key_record* start = reinterpret_cast<const object_key_record*>(payload + 1);
             const object_key_record* end = start + get_length();
             const object_key_record* i = std::lower_bound(start, end, key, object_key_comparator(text));
-            return (i != end && memcmp(key.data(), text + i->key_start, key.length()) == 0)? i - start : get_length();
+            return (i != end
+                    && (i->key_end - i->key_start) == key.length()
+                    && memcmp(key.data(), text + i->key_start, key.length()) == 0)? i - start : get_length();
         }
 
         // valid iff get_type() is TYPE_INTEGER

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -462,6 +462,17 @@ SUITE(objects) {
         const size_t index_ccc = root.find_object_key(literal("ccc"));
         CHECK_EQUAL(2U, index_ccc);
     }
+
+    TEST(binary_search_handles_prefix_keys) {
+        const sajson::document& document = parse(literal(" { \"prefix_key\" : 0 } "));
+        assert(success(document));
+        const value& root = document.get_root();
+        CHECK_EQUAL(TYPE_OBJECT, root.get_type());
+        CHECK_EQUAL(1u, root.get_length());
+
+        const size_t index_prefix = root.find_object_key(literal("prefix"));
+        CHECK_EQUAL(1U, index_prefix);
+    }
 }
 
 SUITE(errors) {


### PR DESCRIPTION
I am sorry I didn't think of that in the first patch.
