### PR TITLE
Kill the intermediate parsed arrays and objects

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -425,6 +425,11 @@ namespace sajson {
             return std::string(text + payload[0], text + payload[1]);
         }
 
+        const size_t* _internal_get_payload() const {
+            return payload;
+        }
+
+
     private:
         void assert_type(type expected) const {
             assert(expected == get_type());

--- a/swift/sajson/sajson-ffi.cpp
+++ b/swift/sajson/sajson-ffi.cpp
@@ -3,6 +3,7 @@
 
 // never instantiated, only inherits so static_cast is legal
 struct sajson_document: sajson::document {};
+struct sajson_value: sajson::value {};
 
 static sajson::document* unwrap(sajson_document* doc) {
     return static_cast<sajson::document*>(doc);
@@ -58,4 +59,34 @@ const unsigned char* sajson_get_input(sajson_document* doc) {
 
 size_t sajson_get_input_length(struct sajson_document* doc) {
     return unwrap(doc)->_internal_get_input().length();
+}
+
+// MARK: -
+/// TODO: The following should be removed when they can be ported to Swift:
+
+static sajson_value* wrap(sajson::value* doc) {
+    return static_cast<sajson_value*>(doc);
+}
+
+static sajson::value* unwrap(sajson_value* value) {
+    return static_cast<sajson::value*>(value);
+}
+
+const sajson_element* sajson_get_value_payload(struct sajson_value* value) {
+    return unwrap(value)->_internal_get_payload();
+}
+
+uint8_t sajson_get_value_type(sajson_value* value) {
+    return unwrap(value)->get_type();
+}
+
+sajson_value* sajson_create_value(size_t type, const size_t* payload, const unsigned char* input) {
+    auto inputCasted = reinterpret_cast<const char*>(input);
+    auto value = sajson::value(sajson::type(type), payload, inputCasted);
+    return wrap(new(std::nothrow) sajson::value(std::move(value)));
+}
+
+sajson_value* sajson_object_get_value_of_key(sajson_value* parentValue, const char* key, size_t length) {
+    auto value = unwrap(parentValue)->get_value_of_key(sajson::string(key, length));
+    return wrap(new(std::nothrow) sajson::value(std::move(value)));
 }

--- a/swift/sajson/sajson-swift/sajson_header_wrapper.h
+++ b/swift/sajson/sajson-swift/sajson_header_wrapper.h
@@ -9,6 +9,7 @@
 #endif
 
 struct sajson_document;
+struct sajson_value;
 
 // size_t gets turned into Int but we want unsigned on the Swift side
 typedef unsigned long sajson_element;
@@ -30,6 +31,12 @@ extern "C" {
     const sajson_element* sajson_get_root(struct sajson_document* doc);
     const unsigned char* sajson_get_input(struct sajson_document* doc);
     size_t sajson_get_input_length(struct sajson_document* doc);
+
+    // TODO: The following should be removed when they can be ported to Swift:
+    const sajson_element* sajson_get_value_payload(struct sajson_value* value);
+    uint8_t sajson_get_value_type(struct sajson_value* value);
+    struct sajson_value* sajson_create_value(size_t type, const sajson_element* payload, const unsigned char* input);
+    struct sajson_value* sajson_object_get_value_of_key(struct sajson_value* parent, const char* bytes, size_t length);
 
 #ifdef __cplusplus
 }

--- a/swift/sajsonTests/sajsonTests.swift
+++ b/swift/sajsonTests/sajsonTests.swift
@@ -22,9 +22,9 @@ class sajsonTests: XCTestCase {
         let doc = try! parse(allocationStrategy: .single, input: "{\"hello\": \"world\"}")
         let docValue = doc.swiftValue
 
-        guard case .object(let object) = docValue else { XCTFail(); return }
-        XCTAssert(object.count == 1)
-        guard case .some(.string("world")) = object["hello"] else { XCTFail(); return }
+        guard case .object(let objectReader) = docValue else { XCTFail(); return }
+        XCTAssert(objectReader.count == 1)
+        guard case .some(.string("world")) = objectReader["hello"] else { XCTFail(); return }
     }
 
     // MARK: Benchmarks
@@ -44,6 +44,8 @@ class sajsonTests: XCTestCase {
         measure {
             let doc = try! parse(allocationStrategy: .single, input: largeJsonData)
             let swiftValue = doc.swiftValue
+
+            XCTAssert(swiftValue.array?[0].object?["0"]?.string != nil)
 
             guard case .array(let array) = swiftValue else {
                 preconditionFailure()


### PR DESCRIPTION
Allow indirect iterating over arrays/objects, rather than constructing an intermediate representation.

There's a lot of hacky calls into C, so i'm pretty confident this could be a lot better. Feel free to patch in and fix if there are large changes. It seems to be quite a bit slower than the current API (50% slower), probably because of all the calls out of swift.