### PR TITLE
Null termination of input strings

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -420,6 +420,12 @@ namespace sajson {
         }
 
         // valid iff get_type() is TYPE_STRING
+        const char* get_string_value() const {
+            assert_type(TYPE_STRING);
+            return text + payload[0];
+        }
+
+        // valid iff get_type() is TYPE_STRING
         std::string as_string() const {
             assert_type(TYPE_STRING);
             return std::string(text + payload[0], text + payload[1]);
@@ -1691,6 +1697,7 @@ namespace sajson {
             if (SAJSON_LIKELY(*p == '"')) {
                 tag[0] = start;
                 tag[1] = p - input.get_data();
+                *p = '\0';
                 return p + 1;
             }
 
@@ -1759,6 +1766,7 @@ namespace sajson {
                     case '"':
                         tag[0] = start;
                         tag[1] = end - input.get_data();
+                        *end = '\0';
                         return p + 1;
 
                     case '\\':

--- a/include/sajson.h
+++ b/include/sajson.h
@@ -269,7 +269,7 @@ namespace sajson {
         char* get_data() const {
             return data;
         }
-        
+
     private:
         refcount uses;
         size_t length_;
@@ -462,7 +462,7 @@ namespace sajson {
         : p(p.p) {
             p.p = 0;
         }
-        
+
         ~ownership() {
             delete[] p;
         }
@@ -531,12 +531,12 @@ namespace sajson {
         const std::string& get_error_message() const {
             return error_message;
         }
-        
+
         /// WARNING: Internal function exposed only for high-performance language bindings.
         type _internal_get_root_type() const {
             return root_type;
         }
-        
+
         /// WARNING: Internal function exposed only for high-performance language bindings.
         const size_t* _internal_get_root() const {
             return root;
@@ -632,7 +632,7 @@ namespace sajson {
                 , write_cursor(structure_end)
                 , should_deallocate(should_deallocate)
             {}
-            
+
             explicit allocator(std::nullptr_t)
                 : structure(0)
                 , structure_end(0)
@@ -1064,7 +1064,7 @@ namespace sajson {
 
             error_line = 1;
             error_column = 1;
-            
+
             char* c = input.get_data();
             while (c < p) {
                 if (*c == '\r') {
@@ -1085,7 +1085,7 @@ namespace sajson {
                 }
                 ++c;
             }
-            
+
             char buf[1024];
             buf[1023] = 0;
             va_list ap;
@@ -1405,7 +1405,7 @@ namespace sajson {
             }
             return p + 4;
         }
-        
+
         static double pow10(int exponent) {
             if (exponent > 308) {
                 return std::numeric_limits<double>::infinity();
@@ -1494,7 +1494,7 @@ namespace sajson {
                 if (c < '0' || c > '9') {
                     break;
                 }
-                
+
                 ++p;
                 if (SAJSON_UNLIKELY(at_eof(p))) {
                     return std::make_pair(error(p, "unexpected end of input"), TYPE_NULL);
@@ -1656,7 +1656,7 @@ namespace sajson {
                 type element_type = get_element_type(element);
                 size_t element_value = get_element_value(element);
                 size_t* element_ptr = structure_end - element_value;
-                
+
                 *--out = make_element(element_type, element_ptr - new_base);
                 *--out = *--object_end;
                 *--out = *--object_end;
@@ -1745,7 +1745,7 @@ namespace sajson {
         char* parse_string_slow(char* p, size_t* tag, size_t start) {
             char* end = p;
             char* input_end_local = input_end;
-            
+
             for (;;) {
                 if (SAJSON_UNLIKELY(p >= input_end_local)) {
                     return error(p, "unexpected end of input");
@@ -1754,7 +1754,7 @@ namespace sajson {
                 if (SAJSON_UNLIKELY(*p >= 0 && *p < 0x20)) {
                     return error(p, "illegal unprintable codepoint in string: %d", static_cast<int>(*p));
                 }
-            
+
                 switch (*p) {
                     case '"':
                         tag[0] = start;
@@ -1771,7 +1771,7 @@ namespace sajson {
                         switch (*p) {
                             case '"': replacement = '"'; goto replace;
                             case '\\': replacement = '\\'; goto replace;
-                            case '/': replacement = '/'; goto replace; 
+                            case '/': replacement = '/'; goto replace;
                             case 'b': replacement = '\b'; goto replace;
                             case 'f': replacement = '\f'; goto replace;
                             case 'n': replacement = '\n'; goto replace;
@@ -1819,7 +1819,7 @@ namespace sajson {
                                 return error(p, "unknown escape");
                         }
                         break;
-                        
+
                     default:
                         // validate UTF-8
                         unsigned char c0 = p[0];

--- a/include/sajson.h
+++ b/include/sajson.h
@@ -420,7 +420,9 @@ namespace sajson {
         }
 
         // valid iff get_type() is TYPE_STRING
-        const char* get_string_value() const {
+        // WARNING: if a string has embedded NULs, it will be appear
+        // truncated to the caller of this function.
+        const char* as_cstring() const {
             assert_type(TYPE_STRING);
             return text + payload[0];
         }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -402,13 +402,13 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(0u, e0.get_string_length());
         CHECK_EQUAL("", e0.as_string());
-        CHECK_EQUAL("", e0.get_string_value());
+        CHECK_EQUAL("", e0.as_cstring());
 
         const value& e1 = root.get_array_element(1);
         CHECK_EQUAL(TYPE_STRING, e1.get_type());
         CHECK_EQUAL(6u, e1.get_string_length());
         CHECK_EQUAL("foobar", e1.as_string());
-        CHECK_EQUAL("foobar", e1.get_string_value());
+        CHECK_EQUAL("foobar", e1.as_cstring());
     }
 
     ABSTRACT_TEST(common_escapes) {
@@ -423,7 +423,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(8u, e0.get_string_length());
         CHECK_EQUAL("\"\\/\b\f\n\r\t", e0.as_string());
-        CHECK_EQUAL("\"\\/\b\f\n\r\t", e0.get_string_value());
+        CHECK_EQUAL("\"\\/\b\f\n\r\t", e0.as_cstring());
     }
 
     ABSTRACT_TEST(escape_midstring) {
@@ -437,7 +437,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(7u, e0.get_string_length());
         CHECK_EQUAL("foo\tbar", e0.as_string());
-        CHECK_EQUAL("foo\tbar", e0.get_string_value());
+        CHECK_EQUAL("foo\tbar", e0.as_cstring());
     }
 
     ABSTRACT_TEST(unfinished_string) {
@@ -482,7 +482,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(4u, e0.get_string_length());
         CHECK_EQUAL("\xf1\xa4\x8c\xa1", e0.as_string());
-        CHECK_EQUAL("\xf1\xa4\x8c\xa1", e0.get_string_value());
+        CHECK_EQUAL("\xf1\xa4\x8c\xa1", e0.as_cstring());
     }
 
     ABSTRACT_TEST(utf8_shifting) {
@@ -497,7 +497,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(10u, e0.get_string_length());
         CHECK_EQUAL("\n\xc2\x80\xe0\xa0\x80\xf0\x90\x80\x80", e0.as_string());
-        CHECK_EQUAL("\n\xc2\x80\xe0\xa0\x80\xf0\x90\x80\x80", e0.get_string_value());
+        CHECK_EQUAL("\n\xc2\x80\xe0\xa0\x80\xf0\x90\x80\x80", e0.as_cstring());
     }
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -77,7 +77,7 @@ ABSTRACT_TEST(nested_array) {
     const value& root = document.get_root();
     CHECK_EQUAL(TYPE_ARRAY, root.get_type());
     CHECK_EQUAL(1u, root.get_length());
-        
+
     const value& e1 = root.get_array_element(0);
     CHECK_EQUAL(TYPE_ARRAY, e1.get_type());
     CHECK_EQUAL(0u, e1.get_length());
@@ -125,7 +125,7 @@ ABSTRACT_TEST(deep_nesting) {
     const value& root = document.get_root();
     CHECK_EQUAL(TYPE_ARRAY, root.get_type());
     CHECK_EQUAL(1u, root.get_length());
-        
+
     const value& e1 = root.get_array_element(0);
     CHECK_EQUAL(TYPE_ARRAY, e1.get_type());
     CHECK_EQUAL(1u, e1.get_length());
@@ -145,7 +145,7 @@ ABSTRACT_TEST(more_array_integer_packing) {
     const value& root = document.get_root();
     CHECK_EQUAL(TYPE_ARRAY, root.get_type());
     CHECK_EQUAL(1u, root.get_length());
-        
+
     const value& e1 = root.get_array_element(0);
     CHECK_EQUAL(TYPE_ARRAY, e1.get_type());
     CHECK_EQUAL(1u, e1.get_length());
@@ -233,7 +233,7 @@ ABSTRACT_TEST(unit_types) {
 
     const value& e1 = root.get_array_element(1);
     CHECK_EQUAL(TYPE_FALSE, e1.get_type());
-        
+
     const value& e2 = root.get_array_element(2);
     CHECK_EQUAL(TYPE_NULL, e2.get_type());
 }
@@ -285,7 +285,7 @@ SUITE(doubles) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(2u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_DOUBLE, e0.get_type());
         CHECK_EQUAL(9999999999.0, e0.get_double_value());
@@ -301,7 +301,7 @@ SUITE(doubles) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(1u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_DOUBLE, e0.get_type());
         CHECK_EQUAL(5.0, e0.get_double_value());
@@ -397,12 +397,12 @@ SUITE(strings) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(2u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(0u, e0.get_string_length());
         CHECK_EQUAL("", e0.as_string());
-        
+
         const value& e1 = root.get_array_element(1);
         CHECK_EQUAL(TYPE_STRING, e1.get_type());
         CHECK_EQUAL(6u, e1.get_string_length());
@@ -416,7 +416,7 @@ SUITE(strings) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(1u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(8u, e0.get_string_length());
@@ -429,7 +429,7 @@ SUITE(strings) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(1u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(7u, e0.get_string_length());
@@ -473,7 +473,7 @@ SUITE(strings) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(1u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(4u, e0.get_string_length());
@@ -487,7 +487,7 @@ SUITE(strings) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
         CHECK_EQUAL(1u, root.get_length());
-        
+
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(10u, e0.get_string_length());
@@ -544,7 +544,7 @@ SUITE(objects) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_OBJECT, root.get_type());
         CHECK_EQUAL(2u, root.get_length());
-        
+
         const string& k0 = root.get_object_key(0);
         const value& e0 = root.get_object_value(0);
         CHECK_EQUAL("a", k0.as_string());
@@ -564,7 +564,7 @@ SUITE(objects) {
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_OBJECT, root.get_type());
         CHECK_EQUAL(2u, root.get_length());
-        
+
         const string& k0 = root.get_object_key(0);
         const value& e0 = root.get_object_value(0);
         CHECK_EQUAL("b", k0.as_string());
@@ -613,7 +613,7 @@ SUITE(objects) {
 
         int ib = root.get_value_of_key(literal("b")).get_integer_value();
         CHECK_EQUAL(123, ib);
-        
+
         int iaa = root.get_value_of_key(literal("aa")).get_integer_value();
         CHECK_EQUAL(456, iaa);
     }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -402,11 +402,13 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(0u, e0.get_string_length());
         CHECK_EQUAL("", e0.as_string());
+        CHECK_EQUAL("", e0.get_string_value());
 
         const value& e1 = root.get_array_element(1);
         CHECK_EQUAL(TYPE_STRING, e1.get_type());
         CHECK_EQUAL(6u, e1.get_string_length());
         CHECK_EQUAL("foobar", e1.as_string());
+        CHECK_EQUAL("foobar", e1.get_string_value());
     }
 
     ABSTRACT_TEST(common_escapes) {
@@ -421,6 +423,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(8u, e0.get_string_length());
         CHECK_EQUAL("\"\\/\b\f\n\r\t", e0.as_string());
+        CHECK_EQUAL("\"\\/\b\f\n\r\t", e0.get_string_value());
     }
 
     ABSTRACT_TEST(escape_midstring) {
@@ -434,6 +437,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(7u, e0.get_string_length());
         CHECK_EQUAL("foo\tbar", e0.as_string());
+        CHECK_EQUAL("foo\tbar", e0.get_string_value());
     }
 
     ABSTRACT_TEST(unfinished_string) {
@@ -478,6 +482,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(4u, e0.get_string_length());
         CHECK_EQUAL("\xf1\xa4\x8c\xa1", e0.as_string());
+        CHECK_EQUAL("\xf1\xa4\x8c\xa1", e0.get_string_value());
     }
 
     ABSTRACT_TEST(utf8_shifting) {
@@ -492,6 +497,7 @@ SUITE(strings) {
         CHECK_EQUAL(TYPE_STRING, e0.get_type());
         CHECK_EQUAL(10u, e0.get_string_length());
         CHECK_EQUAL("\n\xc2\x80\xe0\xa0\x80\xf0\x90\x80\x80", e0.as_string());
+        CHECK_EQUAL("\n\xc2\x80\xe0\xa0\x80\xf0\x90\x80\x80", e0.get_string_value());
     }
 }
 
@@ -512,10 +518,12 @@ SUITE(objects) {
         CHECK_EQUAL(1u, root.get_length());
 
         const string& key = root.get_object_key(0);
+        CHECK_EQUAL("a", key.data());
         CHECK_EQUAL("a", key.as_string());
 
         const value& element = root.get_object_value(0);
         CHECK_EQUAL(TYPE_OBJECT, element.get_type());
+        CHECK_EQUAL("b", element.get_object_key(0).data());
         CHECK_EQUAL("b", element.get_object_key(0).as_string());
 
         const value& inner = element.get_object_value(0);
@@ -531,6 +539,7 @@ SUITE(objects) {
         CHECK_EQUAL(1u, root.get_length());
 
         const string& key = root.get_object_key(0);
+        CHECK_EQUAL("a", key.data());
         CHECK_EQUAL("a", key.as_string());
 
         const value& element = root.get_object_value(0);
@@ -547,12 +556,14 @@ SUITE(objects) {
 
         const string& k0 = root.get_object_key(0);
         const value& e0 = root.get_object_value(0);
+        CHECK_EQUAL("a", k0.data());
         CHECK_EQUAL("a", k0.as_string());
         CHECK_EQUAL(TYPE_INTEGER, e0.get_type());
         CHECK_EQUAL(0, e0.get_integer_value());
 
         const string& k1 = root.get_object_key(1);
         const value& e1 = root.get_object_value(1);
+        CHECK_EQUAL("b", k1.data());
         CHECK_EQUAL("b", k1.as_string());
         CHECK_EQUAL(TYPE_INTEGER, e1.get_type());
         CHECK_EQUAL(1, e1.get_integer_value());
@@ -567,12 +578,14 @@ SUITE(objects) {
 
         const string& k0 = root.get_object_key(0);
         const value& e0 = root.get_object_value(0);
+        CHECK_EQUAL("b", k0.data());
         CHECK_EQUAL("b", k0.as_string());
         CHECK_EQUAL(TYPE_INTEGER, e0.get_type());
         CHECK_EQUAL(1, e0.get_integer_value());
 
         const string& k1 = root.get_object_key(1);
         const value& e1 = root.get_object_value(1);
+        CHECK_EQUAL("aa", k1.data());
         CHECK_EQUAL("aa", k1.as_string());
         CHECK_EQUAL(TYPE_INTEGER, e1.get_type());
         CHECK_EQUAL(0, e1.get_integer_value());


### PR DESCRIPTION
As discussed before here: https://github.com/chadaustin/sajson/issues/13

Currently the only way to get a string value is to risk an allocation (since it's gotten by `std::string as_string()`). With null termination there is a safe way to get it as `const char*` with no allocations needed