### PR TITLE
avoid GCC warning -Wignored-qualifiers

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -147,7 +147,7 @@ namespace sajson {
             return text;
         }
 
-        const size_t length() const {
+        size_t length() const {
             return _length;
         }
 


### PR DESCRIPTION
The warning was:
include/sajson.h:150:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
         const size_t length() const {