### PR TITLE
fix header include

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <assert.h>
-#include <stdarg.h>
+#include <stdint.h>
 #include <stddef.h>
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
stdint.h is needed for uint8_t (I got the error below) and stdarg.h (variadic functions) seems to be not used.

In file included from tests/test_no_stl.cpp:2:
include/sajson.h:79:15: error: unknown type name 'uint8_t'
        const uint8_t globals_struct<unused>::parse_flags[256] = {