### PR TITLE
preserve the order of keys if SAJSON_UNSORTED_OBJECT_KEYS is defined

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -25,7 +25,9 @@ unittestpp_env.Library(
       'third-party/UnitTest++/src/Posix/TimeHelpers.cpp' ])
 
 test_env = env.Clone(tools=[unittestpp, sajson])
-test_env.Program('test', ['tests/test.cpp', 'tests/test_no_stl.cpp'])
+test_env.Program('test', ['tests/test.cpp',
+                          'tests/test_no_stl.cpp',
+                          'tests/test_unsorted.cpp'])
 
 bench_env = env.Clone(tools=[sajson])
 bench_env.Append(CPPDEFINES=['NDEBUG'])

--- a/SConscript
+++ b/SConscript
@@ -25,9 +25,8 @@ unittestpp_env.Library(
       'third-party/UnitTest++/src/Posix/TimeHelpers.cpp' ])
 
 test_env = env.Clone(tools=[unittestpp, sajson])
-test_env.Program('test', ['tests/test.cpp',
-                          'tests/test_no_stl.cpp',
-                          'tests/test_unsorted.cpp'])
+#test_env.Append(CPPDEFINES=['SAJSON_UNSORTED_OBJECT_KEYS'])
+test_env.Program('test', ['tests/test.cpp', 'tests/test_no_stl.cpp'])
 
 bench_env = env.Clone(tools=[sajson])
 bench_env.Append(CPPDEFINES=['NDEBUG'])

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -640,6 +640,7 @@ SUITE(objects) {
         CHECK_EQUAL(0, element.get_integer_value());
     }
 
+#ifndef SAJSON_UNSORTED_OBJECT_KEYS
     ABSTRACT_TEST(object_keys_are_sorted) {
         const sajson::document& document = parse(literal(" { \"b\" : 1 , \"a\" : 0 } "));
         assert(success(document));
@@ -683,8 +684,9 @@ SUITE(objects) {
         CHECK_EQUAL(TYPE_INTEGER, e1.get_type());
         CHECK_EQUAL(0, e1.get_integer_value());
     }
+#endif // not SAJSON_UNSORTED_OBJECT_KEYS
 
-    ABSTRACT_TEST(binary_search_for_keys) {
+    ABSTRACT_TEST(search_for_keys) {
         const sajson::document& document = parse(literal(" { \"b\" : 1 , \"aa\" : 0 } "));
         assert(success(document));
         const value& root = document.get_root();

--- a/tests/test_unsorted.cpp
+++ b/tests/test_unsorted.cpp
@@ -1,0 +1,2 @@
+#define SAJSON_UNSORTED_OBJECT_KEYS
+#include <sajson.h>

--- a/tests/test_unsorted.cpp
+++ b/tests/test_unsorted.cpp
@@ -1,2 +1,0 @@
-#define SAJSON_UNSORTED_OBJECT_KEYS
-#include <sajson.h>


### PR DESCRIPTION
A minimalistic implementation with working get_value_of_key(),
although it may be a little confusing.

(I'll be off until September and may not be replying)