### PR TITLE
added docsforge docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Documentation](https://img.shields.io/badge/docs-docsforge-blue)](http://sajson.docsforge.com/)
+
 # sajson
 
 sajson is an extremely high-performance, in-place, DOM-style JSON parser written in C++.

--- a/doc/docsforge.yaml
+++ b/doc/docsforge.yaml
@@ -1,0 +1,35 @@
+sidebar:
+  Basic Tutorial:
+  - Getting Started: README.md
+  Examples:
+  - main.cpp: example/main.cpp
+  - zero-allocation.cpp: example/zero-allocation.cpp
+
+
+autodocSettings:
+  Public API:
+    language: cpp
+    INPUT: include/sajson.h
+    EXCLUDE: test tests examples
+    EXCLUDE_PATTERNS: '*/tests/* */test/*'
+    includeApi: []
+    excludeApi: []
+    documentSingleUnderscore: true
+    documentStatic: true
+    documentProtected: true
+    extractNonDocComments: false
+    extract_namespace_comments: true
+    sort_by_type: true
+    sort_alphabetically: true
+    separate_defines: false
+    star_mentioned: true
+    star_list: []
+    ENABLE_PREPROCESSING: 'YES'
+    MACRO_EXPANSION: 'NO'
+    EXPAND_ONLY_PREDEF: 'NO'
+    PREDEFINED: ''
+    SEARCH_INCLUDES: 'YES'
+    INCLUDE_PATH: ''
+    INCLUDE_FILE_PATTERNS: ''
+    ALIASES: ''
+    EXAMPLE_PATH: ''


### PR DESCRIPTION
Added link to docsforge. See #49 

Added yaml configuration file that defines the documentation layout.

Docsforge can either use a yaml file edited online (https://sajson.docsforge.com/versions/) or edit the yaml file in your repository.

To edit online, you'll need to be "sajson" maintainer on docsforge, so you can sign in to docsforge, pm me, and I'll transfer project ownership to you. 

Whichever you prefer :) 