### PR TITLE
Preserve double values

### DIFF
--- a/include/sajson.h
+++ b/include/sajson.h
@@ -1983,46 +1983,24 @@ private:
         return p + 4;
     }
 
-    static double pow10(int64_t exponent) {
+    static double make_pow10(double d, int64_t exponent) {
         if (SAJSON_UNLIKELY(exponent > 308)) {
             return std::numeric_limits<double>::infinity();
         } else if (SAJSON_UNLIKELY(exponent < -323)) {
             return 0.0;
+        } else if (SAJSON_UNLIKELY(exponent < -308)) {
+            // clang-format off
+            static constexpr double lut[] = {
+                1e-323,1e-322,1e-321,1e-320,1e-319,1e-318,1e-317,1e-316,1e-315,1e-314,
+                1e-313,1e-312,1e-311,1e-310,1e-309,
+            };
+            // clang-format on
+            return d * lut[exponent + 323];
         }
 
         // clang-format off
-        static const double constants[] = {
-            1e-323,1e-322,1e-321,1e-320,1e-319,1e-318,1e-317,1e-316,1e-315,1e-314,
-            1e-313,1e-312,1e-311,1e-310,1e-309,1e-308,1e-307,1e-306,1e-305,1e-304,
-            1e-303,1e-302,1e-301,1e-300,1e-299,1e-298,1e-297,1e-296,1e-295,1e-294,
-            1e-293,1e-292,1e-291,1e-290,1e-289,1e-288,1e-287,1e-286,1e-285,1e-284,
-            1e-283,1e-282,1e-281,1e-280,1e-279,1e-278,1e-277,1e-276,1e-275,1e-274,
-            1e-273,1e-272,1e-271,1e-270,1e-269,1e-268,1e-267,1e-266,1e-265,1e-264,
-            1e-263,1e-262,1e-261,1e-260,1e-259,1e-258,1e-257,1e-256,1e-255,1e-254,
-            1e-253,1e-252,1e-251,1e-250,1e-249,1e-248,1e-247,1e-246,1e-245,1e-244,
-            1e-243,1e-242,1e-241,1e-240,1e-239,1e-238,1e-237,1e-236,1e-235,1e-234,
-            1e-233,1e-232,1e-231,1e-230,1e-229,1e-228,1e-227,1e-226,1e-225,1e-224,
-            1e-223,1e-222,1e-221,1e-220,1e-219,1e-218,1e-217,1e-216,1e-215,1e-214,
-            1e-213,1e-212,1e-211,1e-210,1e-209,1e-208,1e-207,1e-206,1e-205,1e-204,
-            1e-203,1e-202,1e-201,1e-200,1e-199,1e-198,1e-197,1e-196,1e-195,1e-194,
-            1e-193,1e-192,1e-191,1e-190,1e-189,1e-188,1e-187,1e-186,1e-185,1e-184,
-            1e-183,1e-182,1e-181,1e-180,1e-179,1e-178,1e-177,1e-176,1e-175,1e-174,
-            1e-173,1e-172,1e-171,1e-170,1e-169,1e-168,1e-167,1e-166,1e-165,1e-164,
-            1e-163,1e-162,1e-161,1e-160,1e-159,1e-158,1e-157,1e-156,1e-155,1e-154,
-            1e-153,1e-152,1e-151,1e-150,1e-149,1e-148,1e-147,1e-146,1e-145,1e-144,
-            1e-143,1e-142,1e-141,1e-140,1e-139,1e-138,1e-137,1e-136,1e-135,1e-134,
-            1e-133,1e-132,1e-131,1e-130,1e-129,1e-128,1e-127,1e-126,1e-125,1e-124,
-            1e-123,1e-122,1e-121,1e-120,1e-119,1e-118,1e-117,1e-116,1e-115,1e-114,
-            1e-113,1e-112,1e-111,1e-110,1e-109,1e-108,1e-107,1e-106,1e-105,1e-104,
-            1e-103,1e-102,1e-101,1e-100,1e-99,1e-98,1e-97,1e-96,1e-95,1e-94,1e-93,
-            1e-92,1e-91,1e-90,1e-89,1e-88,1e-87,1e-86,1e-85,1e-84,1e-83,1e-82,1e-81,
-            1e-80,1e-79,1e-78,1e-77,1e-76,1e-75,1e-74,1e-73,1e-72,1e-71,1e-70,1e-69,
-            1e-68,1e-67,1e-66,1e-65,1e-64,1e-63,1e-62,1e-61,1e-60,1e-59,1e-58,1e-57,
-            1e-56,1e-55,1e-54,1e-53,1e-52,1e-51,1e-50,1e-49,1e-48,1e-47,1e-46,1e-45,
-            1e-44,1e-43,1e-42,1e-41,1e-40,1e-39,1e-38,1e-37,1e-36,1e-35,1e-34,1e-33,
-            1e-32,1e-31,1e-30,1e-29,1e-28,1e-27,1e-26,1e-25,1e-24,1e-23,1e-22,1e-21,
-            1e-20,1e-19,1e-18,1e-17,1e-16,1e-15,1e-14,1e-13,1e-12,1e-11,1e-10,1e-9,
-            1e-8,1e-7,1e-6,1e-5,1e-4,1e-3,1e-2,1e-1,1e0,1e1,1e2,1e3,1e4,1e5,1e6,1e7,
+        static constexpr double lut[] = {
+            1e0,1e1,1e2,1e3,1e4,1e5,1e6,1e7,
             1e8,1e9,1e10,1e11,1e12,1e13,1e14,1e15,1e16,1e17,1e18,1e19,1e20,1e21,
             1e22,1e23,1e24,1e25,1e26,1e27,1e28,1e29,1e30,1e31,1e32,1e33,1e34,1e35,
             1e36,1e37,1e38,1e39,1e40,1e41,1e42,1e43,1e44,1e45,1e46,1e47,1e48,1e49,
@@ -2050,7 +2028,11 @@ private:
         };
         // clang-format on
 
-        return constants[exponent + 323];
+        if (SAJSON_LIKELY(exponent < 0)) {
+            return d / lut[-exponent];
+        } else {
+            return d * lut[exponent];
+        }
     }
 
     std::pair<char*, internal::tag> parse_number(char* p) {
@@ -2194,7 +2176,7 @@ private:
                 if (exp > (INT_MAX - digit) / 10) {
                     // The exponent overflowed.  Keep parsing, but
                     // it will definitely be out of range when
-                    // pow10 is called.
+                    // make_pow10 is called.
                     exp = INT_MAX;
                 } else {
                     exp = 10 * exp + digit;
@@ -2221,7 +2203,7 @@ private:
             // If d is zero but the exponent is huge, don't
             // multiply zero by inf which gives nan.
             if (d != 0.0) {
-                d *= pow10(exponent);
+                d = make_pow10(d, exponent);
             }
         }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -315,11 +315,11 @@ ABSTRACT_TEST(unit_types) {
 
 SUITE(doubles) {
     ABSTRACT_TEST(doubles) {
-        const sajson::document& document = parse(literal("[-0,-1,-34.25]"));
+        const sajson::document& document = parse(literal("[-0,-1,-34.25,1.65,0.3,3.141592]"));
         assert(success(document));
         const value& root = document.get_root();
         CHECK_EQUAL(TYPE_ARRAY, root.get_type());
-        CHECK_EQUAL(3u, root.get_length());
+        CHECK_EQUAL(6u, root.get_length());
 
         const value& e0 = root.get_array_element(0);
         CHECK_EQUAL(TYPE_INTEGER, e0.get_type());
@@ -332,6 +332,18 @@ SUITE(doubles) {
         const value& e2 = root.get_array_element(2);
         CHECK_EQUAL(TYPE_DOUBLE, e2.get_type());
         CHECK_EQUAL(-34.25, e2.get_double_value());
+
+        const value& e3 = root.get_array_element(3);
+        CHECK_EQUAL(TYPE_DOUBLE, e3.get_type());
+        CHECK_EQUAL(1.65, e3.get_double_value());
+
+        const value& e4 = root.get_array_element(4);
+        CHECK_EQUAL(TYPE_DOUBLE, e4.get_type());
+        CHECK_EQUAL(0.3, e4.get_double_value());
+
+        const value& e5 = root.get_array_element(5);
+        CHECK_EQUAL(TYPE_DOUBLE, e5.get_type());
+        CHECK_EQUAL(3.141592, e5.get_double_value());
     }
 
     ABSTRACT_TEST(large_number) {

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -371,6 +371,32 @@ SUITE(doubles) {
         CHECK_EQUAL(10e22, e2.get_double_value());
     }
 
+    ABSTRACT_TEST(exponent_limits) {
+        const sajson::document& document
+            = parse(literal("[1e-323,1.2e308,1e-324,1e309]"));
+        assert(success(document));
+
+        const value& root = document.get_root();
+        CHECK_EQUAL(TYPE_ARRAY, root.get_type());
+        CHECK_EQUAL(4u, root.get_length());
+
+        const value& e0 = root.get_array_element(0);
+        CHECK_EQUAL(TYPE_DOUBLE, e0.get_type());
+        CHECK_EQUAL(1e-323, e0.get_double_value());
+
+        const value& e1 = root.get_array_element(1);
+        CHECK_EQUAL(TYPE_DOUBLE, e1.get_type());
+        CHECK_EQUAL(1.2e308, e1.get_double_value());
+
+        const value& e2 = root.get_array_element(2);
+        CHECK_EQUAL(TYPE_DOUBLE, e2.get_type());
+        CHECK_EQUAL(0, e2.get_double_value());
+
+        const value& e3 = root.get_array_element(3);
+        CHECK_EQUAL(TYPE_DOUBLE, e3.get_type());
+        CHECK_EQUAL(INFINITY, e3.get_double_value());
+    }
+
     ABSTRACT_TEST(long_no_exponent) {
         const sajson::document& document
             = parse(literal("[9999999999,99999999999]"));


### PR DESCRIPTION
Note the added values in the test `doubles/doubles`: `1.65,0.3,3.141592`

With the original code they were not parsed correctly: not in a way that would compare equal to the same literals in C++ code.

The problem is that the LUT for negative powers of 10 loses precision in the wrong direction:

* 1.65 is not exactly representable with IEEE 754 floats
* The C++ literal `1.65` is roughly equal to 1.6499999999999999112... (the closest representable base-2 fraction)
* `165.0 * 1e-2` rounds in the wrong direction producing 1.6500000000000001332... 
* To get the correct result one needs to divide by a non-truncated number: 100 (1e2)

So, this PR uses division by whole positive powers of 10 for negative exponents as opposed to multiplication by imprecise negative powers of 10. This approach is known as Clinger's fast-path rounding.

> [!WARNING]  
> Division is slower than multiplication on most modern CPUs. 
> As a result float-heavy benchmarks: `mesh.json` and `mesh.pretty.json` are about 10% slower when tested on high-end x86 CPUs.

I'd understand if you don't want to accept the PR given this perf hit. 